### PR TITLE
Support later JVM and IDL-Parser

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ sourceSets {
         }
         resources {
             srcDir 'src/main/resources'
+            include '**/*.stg'
         }
     }
     test {
@@ -60,13 +61,11 @@ jar {
 
 compileJava.dependsOn buildIDLParser
 compileJava {
-    sourceCompatibility = 1.6
-    targetCompatibility = 1.6
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
 }
 
 test {
     systemProperty 'branch', System.getProperty('branch')
     useJUnit()
 }
-
-

--- a/src/main/java/com/eprosima/uxr/idl/grammar/Context.java
+++ b/src/main/java/com/eprosima/uxr/idl/grammar/Context.java
@@ -20,7 +20,7 @@ import java.util.Stack;
 import com.eprosima.idl.parser.tree.Interface;
 import com.eprosima.idl.parser.tree.TypeDeclaration;
 import com.eprosima.idl.parser.tree.Annotation;
-import com.eprosima.idl.parser.typecode.TypeCode;
+import com.eprosima.idl.parser.typecode.Kind;
 import com.eprosima.uxr.idl.parser.typecode.StructTypeCode;
 
 public class Context extends com.eprosima.idl.context.Context implements com.eprosima.uxr.idl.context.Context
@@ -55,7 +55,7 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
     {
         super.addTypeDeclaration(typedecl);
 
-        if(typedecl.getTypeCode().getKind() == TypeCode.KIND_STRUCT && typedecl.isInScope())
+        if(typedecl.getTypeCode().getKind() == Kind.KIND_STRUCT && typedecl.isInScope())
         {
             Annotation topicann = typedecl.getAnnotations().get("Topic");
 

--- a/src/main/java/com/eprosima/uxr/microxrceddsgen.java
+++ b/src/main/java/com/eprosima/uxr/microxrceddsgen.java
@@ -47,7 +47,7 @@ import com.eprosima.idl.parser.tree.Specification;
 import com.eprosima.idl.parser.tree.AnnotationDeclaration;
 import com.eprosima.idl.parser.tree.AnnotationMember;
 import com.eprosima.idl.parser.typecode.PrimitiveTypeCode;
-import com.eprosima.idl.parser.typecode.TypeCode;
+import com.eprosima.idl.parser.typecode.Kind;
 import com.eprosima.idl.util.Util;
 import com.eprosima.log.ColorMessage;
 
@@ -64,6 +64,7 @@ public class microxrceddsgen {
     private String m_tempDir = null;
     protected static String m_appName = "microxrceddsgen";
     protected boolean m_test = false;
+    private boolean m_typesc = false;
 
     protected static String m_localAppProduct = "microxrcedds";
     private ArrayList<String> m_includePaths = new ArrayList<String>();
@@ -110,6 +111,8 @@ public class microxrceddsgen {
                 }
             } else if (arg.equals("-test")) {
                 m_test = true;
+            } else if(arg.equals("-typesc")) {
+                m_typesc = true;
             } else if (arg.equals("-version")) {
                 showVersion();
                 System.exit(0);
@@ -288,14 +291,14 @@ public class microxrceddsgen {
 
             // Create default @Key annotation.
             AnnotationDeclaration keyann = ctx.createAnnotationDeclaration("Key", null);
-            keyann.addMember(new AnnotationMember("value", new PrimitiveTypeCode(TypeCode.KIND_BOOLEAN), "true"));
+            keyann.addMember(new AnnotationMember("value", new PrimitiveTypeCode(Kind.KIND_BOOLEAN), "true"));
 
             // Create default @Topic annotation.
             AnnotationDeclaration topicann = ctx.createAnnotationDeclaration("Topic", null);
-            topicann.addMember(new AnnotationMember("value", new PrimitiveTypeCode(TypeCode.KIND_BOOLEAN), "true"));
+            topicann.addMember(new AnnotationMember("value", new PrimitiveTypeCode(Kind.KIND_BOOLEAN), "true"));
 
             // Create template manager
-            TemplateManager tmanager = new TemplateManager("Common");
+            TemplateManager tmanager = new TemplateManager("Common", ctx, m_typesc);
 
             // Load common types template
             tmanager.addGroup("TypesHeader");

--- a/src/main/resources/com/eprosima/uxr/idl/templates/CMakeLists.stg
+++ b/src/main/resources/com/eprosima/uxr/idl/templates/CMakeLists.stg
@@ -82,3 +82,12 @@ target_compile_options($project.name$SerializationTest
 
 $endif$
 >>
+
+module(ctx, parent, module, definition_list) ::= <<>>
+
+definition_list(definitions) ::= <<>>
+
+typedef_decl(ctx, parent, typedefs) ::= <<>>
+
+const_decl(ctx, parent, const) ::= <<>>
+

--- a/src/main/resources/com/eprosima/uxr/idl/templates/Common.stg
+++ b/src/main/resources/com/eprosima/uxr/idl/templates/Common.stg
@@ -29,7 +29,7 @@ fileHeader(ctx, file, description) ::= <<
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/*! 
+/*!
  * @file $file$
  * $description$
  *
@@ -38,3 +38,12 @@ fileHeader(ctx, file, description) ::= <<
 >>
 
 indexName(name, suffix) ::= <<$name$[i$suffix$]>>
+
+module(ctx, parent, module, definition_list) ::= <<>>
+
+definition_list(definitions) ::= <<>>
+
+typedef_decl(ctx, parent, typedefs) ::= <<>>
+
+const_decl(ctx, parent, const) ::= <<>>
+

--- a/src/main/resources/com/eprosima/uxr/idl/templates/PublisherSource.stg
+++ b/src/main/resources/com/eprosima/uxr/idl/templates/PublisherSource.stg
@@ -58,8 +58,7 @@ int main(void)
 {
     // Transport
     uxrUDPTransport transport;
-    uxrUDPPlatform udp_platform;
-    if(!uxr_init_udp_transport(&transport, &udp_platform, UXR_IPv4, "127.0.0.1", "2018"))
+    if(!uxr_init_udp_transport(&transport, UXR_IPv4, "127.0.0.1", "2018"))
     {
         printf("Error at create transport.\n");
         return 1;

--- a/src/main/resources/com/eprosima/uxr/idl/templates/SerializationTestSource.stg
+++ b/src/main/resources/com/eprosima/uxr/idl/templates/SerializationTestSource.stg
@@ -30,36 +30,36 @@ $fileHeader(ctx=ctx,  file=[ctx.filename, "SerializationTest.c"], description=["
 
 $definitions; separator="\n"$
 
-int test$ctx.lastStructure.name$()
+int test$ctx.lastStructure.cScopedname$()
 {
-    $ctx.lastStructure.name$ $ctx.lastStructure.name$_serialization_topic = {0};
-    $ctx.lastStructure.name$ $ctx.lastStructure.name$_deserialization_topic = {0};
+    $ctx.lastStructure.cScopedname$ $ctx.lastStructure.cScopedname$_serialization_topic = {0};
+    $ctx.lastStructure.cScopedname$ $ctx.lastStructure.cScopedname$_deserialization_topic = {0};
 
-    initialize$ctx.lastStructure.name$(&$ctx.lastStructure.name$_serialization_topic);
+    initialize_$ctx.lastStructure.cScopedname$(&$ctx.lastStructure.cScopedname$_serialization_topic);
 
     uint8_t buffer[BUFFER_SIZE];
     ucdrBuffer mb;
 
     ucdr_init_buffer(&mb, buffer, BUFFER_SIZE);
-    $ctx.lastStructure.name$_serialize_topic(&mb, &$ctx.lastStructure.name$_serialization_topic);
+    $ctx.lastStructure.cScopedname$_serialize_topic(&mb, &$ctx.lastStructure.cScopedname$_serialization_topic);
 
     ucdr_reset_buffer(&mb);
-    $ctx.lastStructure.name$_deserialize_topic(&mb, &$ctx.lastStructure.name$_deserialization_topic);
+    $ctx.lastStructure.cScopedname$_deserialize_topic(&mb, &$ctx.lastStructure.cScopedname$_deserialization_topic);
 
-    uint32_t $ctx.lastStructure.name$_serialization_topic_size = $ctx.lastStructure.name$_size_of_topic(&$ctx.lastStructure.name$_serialization_topic, 0);
-    uint32_t $ctx.lastStructure.name$_deserialization_topic_size = $ctx.lastStructure.name$_size_of_topic(&$ctx.lastStructure.name$_deserialization_topic, 0);
+    uint32_t $ctx.lastStructure.cScopedname$_serialization_topic_size = $ctx.lastStructure.cScopedname$_size_of_topic(&$ctx.lastStructure.cScopedname$_serialization_topic, 0);
+    uint32_t $ctx.lastStructure.cScopedname$_deserialization_topic_size = $ctx.lastStructure.cScopedname$_size_of_topic(&$ctx.lastStructure.cScopedname$_deserialization_topic, 0);
     uint32_t buffer_length = ucdr_buffer_length(&mb);
 
-    int topic_equal = 0 == memcmp(&$ctx.lastStructure.name$_serialization_topic, &$ctx.lastStructure.name$_deserialization_topic, sizeof($ctx.lastStructure.name$));
-    int size_equal = $ctx.lastStructure.name$_serialization_topic_size == $ctx.lastStructure.name$_deserialization_topic_size;
-    size_equal = size_equal && $ctx.lastStructure.name$_serialization_topic_size == buffer_length;
+    int topic_equal = 0 == memcmp(&$ctx.lastStructure.cScopedname$_serialization_topic, &$ctx.lastStructure.cScopedname$_deserialization_topic, sizeof($ctx.lastStructure.cScopedname$));
+    int size_equal = $ctx.lastStructure.cScopedname$_serialization_topic_size == $ctx.lastStructure.cScopedname$_deserialization_topic_size;
+    size_equal = size_equal && $ctx.lastStructure.cScopedname$_serialization_topic_size == buffer_length;
 
     printf("\n");
     printf("===== Before serialize: =====\n");
-    print$ctx.lastStructure.name$(&$ctx.lastStructure.name$_serialization_topic);
+    print_$ctx.lastStructure.cScopedname$(&$ctx.lastStructure.cScopedname$_serialization_topic);
     printf("\n");
     printf("===== After deserialize: =====\n");
-    print$ctx.lastStructure.name$(&$ctx.lastStructure.name$_deserialization_topic);
+    print_$ctx.lastStructure.cScopedname$(&$ctx.lastStructure.cScopedname$_deserialization_topic);
     printf("\n");
     printf("ucdrBuffer: \n");
     printf("length: %d\n", buffer_length);
@@ -70,8 +70,8 @@ int test$ctx.lastStructure.name$()
     }
     printf("\n\n");
 
-    printf("Topic $ctx.lastStructure.name$ size: %s => pre: %d, post: %d, buffer: %d\n", size_equal ? "OK" : "ERROR", $ctx.lastStructure.name$_serialization_topic_size, $ctx.lastStructure.name$_deserialization_topic_size, buffer_length);
-    printf("Topic $ctx.lastStructure.name$ comparation: %s\n", topic_equal ? "OK" : "ERROR");
+    printf("Topic $ctx.lastStructure.cScopedname$ size: %s => pre: %d, post: %d, buffer: %d\n", size_equal ? "OK" : "ERROR", $ctx.lastStructure.cScopedname$_serialization_topic_size, $ctx.lastStructure.cScopedname$_deserialization_topic_size, buffer_length);
+    printf("Topic $ctx.lastStructure.cScopedname$ comparation: %s\n", topic_equal ? "OK" : "ERROR");
 
     return topic_equal && size_equal;
 }
@@ -79,20 +79,20 @@ int test$ctx.lastStructure.name$()
 int main(void)
 {
     srand((unsigned) time(NULL));
-    return test$ctx.lastStructure.name$() ? 0 : 1;
+    return test$ctx.lastStructure.cScopedname$() ? 0 : 1;
 }
 
 >>
 
 struct_type(ctx, parent, struct) ::= <<
-void print$struct.name$($struct.name$* topic)
+void print_$struct.cScopedname$($struct.cScopedname$* topic)
 {
-    printf("$struct.name$: { \n");
+    printf("$struct.cScopedname$: { \n");
     $struct.members:{$member_print(typecode=it.typecode, name=it.name, name=it.name)$}; separator="\n"$
     printf("}\n");
 }
 
-void initialize$struct.name$($struct.name$* topic)
+void initialize_$struct.cScopedname$($struct.cScopedname$* topic)
 {
     $struct.members:{$member_assignment(typecode=it.typecode, name=it.name, name=it.name)$}; separator="\n"$
 }
@@ -118,7 +118,7 @@ $sequence_assigment(typecode=typecode, name=name)$
 $elseif(typecode.isType_f)$
 $array_assigment(typecode=typecode, name=name, originName=originName, dimensions=typecode.dimensions)$
 $else$
-initialize$typecode.cTypename$(&topic->$name$);
+initialize_$typecode.cTypename$(&topic->$name$);
 $endif$
 >>
 
@@ -168,7 +168,7 @@ $sequence_print(typecode=typecode, name=name)$
 $elseif(typecode.isType_f)$
 $array_print(typecode=typecode, name=name, originName=originName, dimensions=typecode.dimensions)$
 $else$
-print$typecode.cTypename$(&topic->$name$);
+print_$typecode.cTypename$(&topic->$name$);
 $endif$
 >>
 
@@ -226,3 +226,16 @@ for(int i = 0; i < sizeof(topic->$name$) / sizeof($typecode.cTypename$); ++i)
 }
 printf("\n");
 >>
+
+
+module(ctx, parent, module, definition_list) ::= <<
+$definition_list$
+>>
+
+definition_list(definitions) ::= <<
+$definitions; separator="\n"$
+>>
+
+typedef_decl(ctx, parent, typedefs) ::= <<>>
+
+const_decl(ctx, parent, const) ::= <<>>

--- a/src/main/resources/com/eprosima/uxr/idl/templates/SubscriberSource.stg
+++ b/src/main/resources/com/eprosima/uxr/idl/templates/SubscriberSource.stg
@@ -72,8 +72,7 @@ int main(void)
 {
     // Transport
     uxrUDPTransport transport;
-    uxrUDPPlatform udp_platform;
-    if(!uxr_init_udp_transport(&transport, &udp_platform, UXR_IPv4, "127.0.0.1", "2018"))
+    if(!uxr_init_udp_transport(&transport, UXR_IPv4, "127.0.0.1", "2018"))
     {
         printf("Error at create transport.\n");
         return 1;

--- a/src/main/resources/com/eprosima/uxr/idl/templates/TypesHeader.stg
+++ b/src/main/resources/com/eprosima/uxr/idl/templates/TypesHeader.stg
@@ -95,7 +95,11 @@ $if(member.typecode.isType_d)$
 $member.typecode.cTypename$ $member.name$[$member.typecode.maxsize$];
 $elseif(member.typecode.isType_e)$
 uint32_t $member.name$_size;
+$if(member.typecode.isType_10)$
+$member.typecode.contentTypeCode.cTypename$ $member.name$[0];
+$else$
 $member.typecode.contentTypeCode.cTypename$ $member.name$$member.typecode.cTypeDimensions$;
+$endif$
 $elseif(member.typecode.isType_f)$
 $member.typecode.cTypename$ $member.name$$member.typecode.cTypeDimensions$;
 $else$

--- a/src/main/resources/com/eprosima/uxr/idl/templates/TypesSource.stg
+++ b/src/main/resources/com/eprosima/uxr/idl/templates/TypesSource.stg
@@ -91,12 +91,22 @@ $sequence_serialization(ctx=ctx, typecode=typecode, name=name)$
 $elseif(typecode.isType_f)$
 $array_serialization(ctx=ctx, typecode=typecode, name=name, originName=originName, dimensions=typecode.dimensions)$
 $else$
-(void) $typecode.scopedname$_serialize_topic(writer, &topic->$name$);
+(void) $typecode.cScopedname$_serialize_topic(writer, &topic->$name$);
 $endif$
 >>
 
 sequence_serialization(ctx, typecode, name) ::= <<
-$if(typecode.contentTypeCode.primitive)$
+$if(typecode.isType_10)$
+$if(typecode.contentTypeCode.isStructType)$
+(void) ucdr_serialize_uint32_t(writer, topic->$name$_size);
+for(int i = 0; i < topic->$name$_size; ++i)
+{
+    $member_serialization(ctx=ctx, typecode=typecode.contentTypeCode, name=indexName(name=name), originName=name)$
+}
+$else$
+(void) ucdr_serialize_sequence_$typecode.contentTypeCode.cTypename$(writer, topic->$name$, topic->$name$_size);
+$endif$
+$elseif(typecode.contentTypeCode.primitive)$
 (void) ucdr_serialize_sequence_$typecode.cTypename$(writer, topic->$name$, topic->$name$_size);
 $else$
 (void) ucdr_serialize_uint32_t(writer, topic->$name$_size);
@@ -141,12 +151,29 @@ $sequence_deserialization(ctx=ctx, typecode=typecode, name=name)$
 $elseif(typecode.isType_f)$
 $array_deserialization(ctx=ctx, typecode=typecode, name=name, originName=originName, dimensions=typecode.dimensions)$
 $else$
-(void) $typecode.scopedname$_deserialize_topic(reader, &topic->$name$);
+(void) $typecode.cScopedname$_deserialize_topic(reader, &topic->$name$);
 $endif$
 >>
 
 sequence_deserialization(ctx, typecode, name) ::= <<
-$if(typecode.contentTypeCode.primitive)$
+$if(typecode.isType_10)$
+$if(typecode.contentTypeCode.isStructType)$
+(void) ucdr_deserialize_uint32_t(reader, &topic->$name$_size);
+if(topic->$name$_size > $typecode.maxsize$)
+{
+    reader->error = true;
+}
+else
+{
+    for(int i = 0; i < topic->$name$_size; ++i)
+    {
+        $member_deserialization(ctx=ctx, typecode=typecode.contentTypeCode, name=indexName(name=name), originName=name)$
+    }
+}
+$else$
+(void) ucdr_deserialize_sequence_$typecode.contentTypeCode.cTypename$(reader, topic->$name$, $typecode.maxsize$, &topic->$name$_size);
+$endif$
+$elseif(typecode.contentTypeCode.primitive)$
 (void) ucdr_deserialize_sequence_$typecode.cTypename$(reader, topic->$name$, $typecode.maxsize$, &topic->$name$_size);
 $else$
 (void) ucdr_deserialize_uint32_t(reader, &topic->$name$_size);
@@ -198,7 +225,7 @@ $sequence_size(ctx=ctx, typecode=typecode, name=name)$
 $elseif(typecode.isType_f)$
 $array_size(ctx=ctx, typecode=typecode, name=name, originName=originName, dimensions=typecode.dimensions)$
 $else$
-size += $typecode.scopedname$_size_of_topic(&topic->$name$, size);
+size += $typecode.cScopedname$_size_of_topic(&topic->$name$, size);
 $endif$
 >>
 


### PR DESCRIPTION
- Bumps `sourceCompatibility` and `targetCompatibility` to support systems with JDK 11 or later
- Bump and add support to IDL-Parser v1.1.0
- Initial support on Pubs/Subs for micro XRCE-DDS Client v2.0 API.

Currently tests are failing for the `sequence_basic` IDL with the following:
```
2021-09-02T16:01:14.236+0100 [DEBUG] [TestEventLogger]     Loading templates...
2021-09-02T16:01:14.236+0100 [DEBUG] [TestEventLogger]     Processing the file thirdparty/IDL-Parser/test/idls/sequence_basic.idl...
2021-09-02T16:01:14.237+0100 [DEBUG] [TestEventLogger]     ERROR<Exception>: Can't find template module.st; group hierarchy is [Common]
2021-09-02T16:01:14.237+0100 [DEBUG] [TestEventLogger]         RESULT: ERROR
```

Not entirely sure where to start to fix this, so I expect someone can help. This happens with IDL-Parser v1.1.0, so I suppose something is missing on `microxrceddsgen` to make it work, as with `fastddsgen` all tests pass.

@pablogs9 FYI and review.