### PR TITLE
Use size_t in for loops to fix integer comparisons

### DIFF
--- a/src/main/resources/com/eprosima/uxr/idl/templates/SerializationSource.stg
+++ b/src/main/resources/com/eprosima/uxr/idl/templates/SerializationSource.stg
@@ -93,7 +93,7 @@ topic->$name$_size = $typecode.maxsize$ / 2;
 $if(typecode.contentTypeCode.primitive)$
 memset(topic->$name$, rand(), topic->$name$_size * $typecode.contentTypeCode.size$);
 $else$
-for(int i = 0; i < topic->$name$_size; ++i)
+for(size_t i = 0; i < topic->$name$_size; ++i)
 {
     $member_assignment(typecode=typecode.contentTypeCode, name=indexName(name=name), originName=name)$
 }
@@ -109,12 +109,12 @@ for(int i$length(dimensions)$ = 0; i$length(dimensions)$ < sizeof(topic->$name$)
 $elseif(typecode.contentTypeCode.primitive)$
 memset(topic->$name$, rand(), sizeof(topic->$name$));
 $elseif(typecode.contentTypeCode.isType_d)$
-for(int i = 0; i < sizeof(topic->$name$) / $typecode.contentTypeCode.maxsize$; ++i)
+for(size_t i = 0; i < sizeof(topic->$name$) / $typecode.contentTypeCode.maxsize$; ++i)
 {
     $member_assignment(typecode=typecode.contentTypeCode, name=indexName(name=name), originName=name)$
 }
 $else$
-for(int i = 0; i < sizeof(topic->$name$) / sizeof($typecode.cTypename$); ++i)
+for(size_t i = 0; i < sizeof(topic->$name$) / sizeof($typecode.cTypename$); ++i)
 {
     $member_assignment(typecode=typecode.contentTypeCode, name=indexName(name=name), originName=name)$
 }
@@ -145,7 +145,7 @@ printf("$name$: ");
 $print_sequence(name)$
 $else$
 printf("$name$: \n");
-for(int i = 0; i < topic->$name$_size; ++i)
+for(size_t i = 0; i < topic->$name$_size; ++i)
 {
     $member_print(typecode=typecode.contentTypeCode, name=indexName(name=name), originName=name)$
 }
@@ -164,13 +164,13 @@ printf("$name$: ");
 $print_array(typecode=typecode, name=name)$
 $elseif(typecode.contentTypeCode.isType_d)$
 printf("$name$: \n");
-for(int i = 0; i < sizeof(topic->$name$) / $typecode.contentTypeCode.maxsize$; ++i)
+for(size_t i = 0; i < sizeof(topic->$name$) / $typecode.contentTypeCode.maxsize$; ++i)
 {
     $member_print(typecode=typecode.contentTypeCode, name=indexName(name=name), originName=name)$
 }
 $else$
 printf("$name$: \n");
-for(int i = 0; i < sizeof(topic->$name$) / sizeof($typecode.cTypename$); ++i)
+for(size_t i = 0; i < sizeof(topic->$name$) / sizeof($typecode.cTypename$); ++i)
 {
     $member_print(typecode=typecode.contentTypeCode, name=indexName(name=name), originName=name)$
 }
@@ -178,7 +178,7 @@ $endif$
 >>
 
 print_sequence(name) ::= <<
-for(int i = 0; i < topic->$name$_size; ++i)
+for(size_t i = 0; i < topic->$name$_size; ++i)
 {
     printf("%" PRIx64 " ", (uint64_t)topic->$name$[i]);
 }
@@ -186,7 +186,7 @@ printf("\n");
 >>
 
 print_array(typecode, name) ::= <<
-for(int i = 0; i < sizeof(topic->$name$) / sizeof($typecode.cTypename$); ++i)
+for(size_t i = 0; i < sizeof(topic->$name$) / sizeof($typecode.cTypename$); ++i)
 {
     printf("%" PRIx64 " ", (uint64_t)topic->$name$[i]);
 }

--- a/src/main/resources/com/eprosima/uxr/idl/templates/SerializationTestSource.stg
+++ b/src/main/resources/com/eprosima/uxr/idl/templates/SerializationTestSource.stg
@@ -65,7 +65,7 @@ int test$ctx.lastStructure.cScopedname$()
     printf("ucdrBuffer: \n");
     printf("length: %d\n", buffer_length);
     printf("data: ");
-    for(int i = 0; i < buffer_length; ++i)
+    for(size_t i = 0; i < buffer_length; ++i)
     {
         printf("%02X ", mb.init[i]);
     }

--- a/src/main/resources/com/eprosima/uxr/idl/templates/TypesSource.stg
+++ b/src/main/resources/com/eprosima/uxr/idl/templates/TypesSource.stg
@@ -124,7 +124,7 @@ $if(typecode.contentTypeCode.primitive)$
 success &= ucdr_serialize_sequence_$typecode.cTypename$(writer, topic->$name$, topic->$name$_size);
 $else$
 success &= ucdr_serialize_uint32_t(writer, topic->$name$_size);
-for(int i = 0; i < topic->$name$_size; ++i)
+for(size_t i = 0; i < topic->$name$_size; ++i)
 {
     $member_serialization(ctx=ctx, typecode=typecode.contentTypeCode, name=indexName(name=name), originName=name)$
 }
@@ -140,12 +140,12 @@ for(int i$length(dimensions)$ = 0; i$length(dimensions)$ < sizeof(topic->$name$)
 $elseif(typecode.contentTypeCode.primitive)$
 success &= ucdr_serialize_array_$typecode.cTypename$(writer, topic->$name$, sizeof(topic->$name$) / sizeof($typecode.cTypename$));
 $elseif(typecode.contentTypeCode.isType_d)$
-for(int i = 0; i < sizeof(topic->$name$) / $typecode.contentTypeCode.maxsize$; ++i)
+for(size_t i = 0; i < sizeof(topic->$name$) / $typecode.contentTypeCode.maxsize$; ++i)
 {
     $member_serialization(ctx=ctx, typecode=typecode.contentTypeCode, name=indexName(name=name), originName=originName)$
 }
 $else$
-for(int i = 0; i < sizeof(topic->$name$) / sizeof($typecode.cTypename$); ++i)
+for(size_t i = 0; i < sizeof(topic->$name$) / sizeof($typecode.cTypename$); ++i)
 {
     $member_serialization(ctx=ctx, typecode=typecode.contentTypeCode, name=indexName(name=name), originName=originName)$
 }
@@ -182,7 +182,7 @@ if(topic->$name$_size > $typecode.maxsize$)
 }
 else
 {
-    for(int i = 0; i < topic->$name$_size; ++i)
+    for(size_t i = 0; i < topic->$name$_size; ++i)
     {
         $member_deserialization(ctx=ctx, typecode=typecode.contentTypeCode, name=indexName(name=name), originName=name)$
     }
@@ -199,12 +199,12 @@ for(int i$length(dimensions)$ = 0; i$length(dimensions)$ < sizeof(topic->$name$)
 $elseif(typecode.contentTypeCode.primitive)$
 success &= ucdr_deserialize_array_$typecode.cTypename$(reader, topic->$name$, sizeof(topic->$name$) / sizeof($typecode.cTypename$));
 $elseif(typecode.contentTypeCode.isType_d)$
-for(int i = 0; i < sizeof(topic->$name$) / $typecode.contentTypeCode.maxsize$; ++i)
+for(size_t i = 0; i < sizeof(topic->$name$) / $typecode.contentTypeCode.maxsize$; ++i)
 {
     $member_deserialization(ctx=ctx, typecode=typecode.contentTypeCode, name=indexName(name=name), originName=originName)$
 }
 $else$
-for(int i = 0; i < sizeof(topic->$name$) / sizeof($typecode.cTypename$); ++i)
+for(size_t i = 0; i < sizeof(topic->$name$) / sizeof($typecode.cTypename$); ++i)
 {
     $member_deserialization(ctx=ctx, typecode=typecode.contentTypeCode, name=indexName(name=name), originName=originName)$
 }
@@ -233,7 +233,7 @@ size += ucdr_alignment(size, 4) + 4;
 $if(typecode.contentTypeCode.primitive)$
 size += ucdr_alignment(size, $typecode.contentTypeCode.size$) + topic->$name$_size * $typecode.contentTypeCode.size$;
 $else$
-for(int i = 0; i < topic->$name$_size; ++i)
+for(size_t i = 0; i < topic->$name$_size; ++i)
 {
     $member_size(ctx=ctx, typecode=typecode.contentTypeCode, name=indexName(name=name), originName=name)$
 }
@@ -249,12 +249,12 @@ for(int i$length(dimensions)$ = 0; i$length(dimensions)$ < sizeof(topic->$name$)
 $elseif(typecode.contentTypeCode.primitive)$
 size += ucdr_alignment(size, $typecode.contentTypeCode.size$) + sizeof(topic->$name$);
 $elseif(typecode.contentTypeCode.isType_d)$
-for(int i = 0; i < sizeof(topic->$name$) / $typecode.contentTypeCode.maxsize$; ++i)
+for(size_t i = 0; i < sizeof(topic->$name$) / $typecode.contentTypeCode.maxsize$; ++i)
 {
     $member_size(ctx=ctx, typecode=typecode.contentTypeCode, name=indexName(name=name), originName=originName)$
 }
 $else$
-for(int i = 0; i < sizeof(topic->$name$) / sizeof($typecode.cTypename$); ++i)
+for(size_t i = 0; i < sizeof(topic->$name$) / sizeof($typecode.cTypename$); ++i)
 {
     $member_size(ctx=ctx, typecode=typecode.contentTypeCode, name=indexName(name=name), originName=originName)$
 }


### PR DESCRIPTION
This removes integer comparsion compiler warnings. 

When using `sizeof()`, you should compare against either a uint32_t, or more generically, a `size_t` to prevent these warnings. 

Solves #63